### PR TITLE
Add NextJS build cache

### DIFF
--- a/.github/workflows/deploy-to-dev.yaml
+++ b/.github/workflows/deploy-to-dev.yaml
@@ -58,10 +58,23 @@ jobs:
         if: false # No unit tests yet
         run: bun test
 
+      - name: Restore cache for NextJS
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: nextjs-${{ hashFiles('**/*.ts', '**/*.tsx') }}
+          restore-keys: nextjs-
+
       - name: Build
         env:
           VERSION: ${{ github.sha }}
         run: bun run build
+
+      - name: Save cache for NextJS
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: nextjs-${{ hashFiles('**/*.ts', '**/*.tsx') }}
 
       - name: Upload static files to CDN
         uses: nais/deploy/actions/cdn-upload/v2@master


### PR DESCRIPTION
# The cache spends more time than it saves!

_At least for now._

## Some numbers from testing
Cache saves 8-10 seconds, depending on the run. Build time typically went from 45 to 36 seconds.
The cache spends around 15-17 seconds (roughly 50-50 restore and save).